### PR TITLE
fix else-if problem

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/RockyTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/RockyTeleOp.java
@@ -108,14 +108,17 @@ public class RockyTeleOp extends LinearOpMode {
             else if(gamepad2.a){
                 robot.chickenFingers.setPower(-0.8); // set power for chicken fingers reverse direction
             }
-            else if(gamepad2.right_bumper){
+            else {
+                robot.chickenFingers.setPower(0);
+            }
+            
+            if(gamepad2.right_bumper){
                 robot.lift.setPower(1.0);
             }
             else if(gamepad2.left_bumper){
                 robot.lift.setPower(-1.0);
             }
             else {
-                robot.chickenFingers.setPower(0);
                 robot.lift.setPower(0);
             }
 


### PR DESCRIPTION
the chicken fingers and the lift were linked with the lift, causing the lift to lock state whenever the chicken fingers were running (and the lift was not running)
